### PR TITLE
Add support for inline SVGs. Add uglify and dedupe plugins in webpack.

### DIFF
--- a/config/webpack/webpack.config.dev.js
+++ b/config/webpack/webpack.config.dev.js
@@ -43,6 +43,12 @@ module.exports = {
           presets: ["react", "es2015"]
         }
       }, {
+        test: /.svg$/,
+        loaders: [
+          "raw",
+          "image-webpack"
+        ]
+      }, {
         test: /\.hbs$/,
         loader: require.resolve("handlebars-loader")
       }, {

--- a/config/webpack/webpack.config.dev.js
+++ b/config/webpack/webpack.config.dev.js
@@ -45,8 +45,8 @@ module.exports = {
       }, {
         test: /.svg$/,
         loaders: [
-          "raw",
-          "image-webpack"
+          require.resolve("raw-loader"),
+          require.resolve("image-webpack-loader")
         ]
       }, {
         test: /\.hbs$/,

--- a/config/webpack/webpack.config.static.js
+++ b/config/webpack/webpack.config.static.js
@@ -1,10 +1,11 @@
 "use strict";
 
-var CleanPlugin = require("clean-webpack-plugin");
 var path = require("path");
+var webpack = require("webpack");
+
+var CleanPlugin = require("clean-webpack-plugin");
 var StaticSiteGeneratorPlugin = require("static-site-generator-webpack-plugin");
 var StatsWriterPlugin = require("webpack-stats-plugin").StatsWriterPlugin;
-var DefinePlugin = require("webpack").DefinePlugin;
 
 var base = require("./webpack.config.dev.js");
 
@@ -29,8 +30,14 @@ module.exports = {
   resolve: base.resolve,
   module: base.module,
   plugins: [
+    new webpack.optimize.DedupePlugin(),
+    new webpack.optimize.UglifyJsPlugin({
+      compress: {
+        warnings: false
+      }
+    }),
     new CleanPlugin([ path.join(ROOT, OUTPUT_DIR) ]),
-    new DefinePlugin({
+    new webpack.DefinePlugin({
       "process.env": {
         // Disable warnings for static build
         NODE_ENV: JSON.stringify("production")

--- a/config/webpack/webpack.config.static.js
+++ b/config/webpack/webpack.config.static.js
@@ -30,17 +30,17 @@ module.exports = {
   resolve: base.resolve,
   module: base.module,
   plugins: [
-    new webpack.optimize.DedupePlugin(),
-    new webpack.optimize.UglifyJsPlugin({
-      compress: {
-        warnings: false
-      }
-    }),
     new CleanPlugin([ path.join(ROOT, OUTPUT_DIR) ]),
     new webpack.DefinePlugin({
       "process.env": {
         // Disable warnings for static build
         NODE_ENV: JSON.stringify("production")
+      }
+    }),
+    new webpack.optimize.DedupePlugin(),
+    new webpack.optimize.UglifyJsPlugin({
+      compress: {
+        warnings: false
       }
     }),
     // TODO: add uglify & dedup https://github.com/FormidableLabs/builder-docs-archetype/issues/1

--- a/package.json
+++ b/package.json
@@ -8,10 +8,9 @@
     "lint-react": "eslint --ext .js,.jsx src",
     "lint-config": "eslint ./*.js",
     "lint": "builder concurrent lint-react lint-config",
-    "update-readme": "npm update",
     "webpack-static": "webpack --config node_modules/builder-docs-archetype/config/webpack/webpack.config.static.js --progress --bail",
     "copy-assets": "cp -r static build/static",
-    "build-static": "npm run update-readme && npm run webpack-static && npm run copy-assets",
+    "build-static": "npm update && builder run webpack-static && builder run copy-assets",
     "open-static": "open http://localhost:8080",
     "server-static": "http-server build",
     "builder:check": "eslint config"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "clean-webpack-plugin": "0.1.5",
     "handlebars": "^4.0.5",
     "handlebars-loader": "^1.1.4",
+    "image-webpack-loader": "^1.6.3",
     "raw-loader": "0.5.1",
     "static-site-generator-webpack-plugin": "2.0.1",
     "webpack": "1.12.9",


### PR DESCRIPTION
Resolves https://github.com/FormidableLabs/builder-docs-archetype/issues/1
- Add `image-webpack-loader` to support inline SVGs (used in `spectacle-docs` and `formidable-landers`)
- Add `uglifyPlugin` and `dedupePlugin` 
