### PR TITLE
Task: Setup webpack for victory-docs

### DIFF
--- a/config/webpack/webpack.config.dev.js
+++ b/config/webpack/webpack.config.dev.js
@@ -37,7 +37,7 @@ module.exports = {
       {
         test: /\.jsx?$/,
         // Exclude formidable-landers for `npm link` purposes
-        exclude: /(node_modules|formidable-landers)/,
+        include: /(src|docs)/,
         loader: require.resolve("babel-loader"),
         query: {
           presets: ["react", "es2015"]

--- a/config/webpack/webpack.config.dev.js
+++ b/config/webpack/webpack.config.dev.js
@@ -36,11 +36,16 @@ module.exports = {
     loaders: [
       {
         test: /\.jsx?$/,
-        // Exclude formidable-landers for `npm link` purposes
-        include: /(src|docs)/,
+        // Make sure to formidable-landers is excluded for `npm link` purposes
+        include: [
+          path.resolve(SRC),
+          path.resolve(ROOT, "node_modules", "victory-chart"),
+          path.resolve(ROOT, "node_modules", "victory-core"),
+          path.resolve(ROOT, "node_modules", "victory-pie")
+        ],
         loader: require.resolve("babel-loader"),
         query: {
-          presets: ["react", "es2015"]
+          presets: ["es2015", "stage-1", "react"]
         }
       }, {
         test: /.svg$/,

--- a/dev/package.json
+++ b/dev/package.json
@@ -14,6 +14,7 @@
     "eslint-plugin-flow-vars": "^0.1.3",
     "eslint-plugin-react": "^3.16.1",
     "http-server": "^0.8.5",
+    "react-docgen": "^2.7.0",
     "webpack-dev-server": "1.14.0"
   },
   "devDependencies": {},

--- a/dev/package.json
+++ b/dev/package.json
@@ -14,7 +14,6 @@
     "eslint-plugin-flow-vars": "^0.1.3",
     "eslint-plugin-react": "^3.16.1",
     "http-server": "^0.8.5",
-    "react-docgen": "^2.7.0",
     "webpack-dev-server": "1.14.0"
   },
   "devDependencies": {},

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "babel-preset-es2015": "6.3.13",
     "babel-preset-react": "6.3.13",
     "clean-webpack-plugin": "0.1.5",
+    "file-loader": "^0.8.5",
     "handlebars": "^4.0.5",
     "handlebars-loader": "^1.1.4",
     "image-webpack-loader": "^1.6.3",


### PR DESCRIPTION
- Use `include` so that we can pull in the docs from the victory components. 
- Add a missing `file-loader` dependency for `victory-docs`. 
- We learned the order matters for `"presets": ["es2015", "stage-1", "react"]` ! 

/cc @coopy @boygirl 
