### PR TITLE
Remove global npm update task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Docs Archetype
+
+# 1.0.0 (2016 Apr 14)
+- Do not apply `npm update` globally; instead, use the local task `update-project` that should be redefined in the project to update specific modules
+
+# 0.0.5 (2016 Apr 14)
+- Add missing dependencies for Victory
+
+# 0.0.4 (2016 Apr 14)
+- Add support for SVGs

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "builder concurrent lint-react lint-config",
     "webpack-static": "webpack --config node_modules/builder-docs-archetype/config/webpack/webpack.config.static.js --progress --bail",
     "copy-assets": "cp -r static build/static",
-    "build-static": "npm update && builder run webpack-static && builder run copy-assets",
+    "update-project": "echo YOU NEED TO DEFINE THIS IN YOUR PROJECT",
+    "build-static": "builder run update-project && builder run webpack-static && builder run copy-assets",
     "open-static": "open http://localhost:8080",
     "server-static": "http-server build",
     "builder:check": "eslint config"


### PR DESCRIPTION
`npm update` will update all node modules globally, but we only just want the specific project to be updated to the latest master to get the latest `README.md`. 

I suspect this global update was upgrading a specific module and causing things to break. This will ensure that doesn’t happen without our consent! 

Also added a `CHANGELOG.md` for future humans.

To upgrade:
- Add an `"update-project"` script to your project’s `package.json`.

/cc @david-davidson @coopy 
