### PR TITLE
Task: Clean build with script

### DIFF
--- a/config/webpack/webpack.config.static.js
+++ b/config/webpack/webpack.config.static.js
@@ -3,7 +3,6 @@
 var path = require("path");
 var webpack = require("webpack");
 
-var CleanPlugin = require("clean-webpack-plugin");
 var StaticSiteGeneratorPlugin = require("static-site-generator-webpack-plugin");
 var StatsWriterPlugin = require("webpack-stats-plugin").StatsWriterPlugin;
 
@@ -30,7 +29,6 @@ module.exports = {
   resolve: base.resolve,
   module: base.module,
   plugins: [
-    new CleanPlugin([ path.join(ROOT, OUTPUT_DIR) ]),
     new webpack.DefinePlugin({
       "process.env": {
         // Disable warnings for static build

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "babel-loader": "6.2.1",
     "babel-preset-es2015": "6.3.13",
     "babel-preset-react": "6.3.13",
-    "clean-webpack-plugin": "0.1.5",
     "file-loader": "^0.8.5",
     "handlebars": "^4.0.5",
     "handlebars-loader": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "webpack-static": "webpack --config node_modules/builder-docs-archetype/config/webpack/webpack.config.static.js --progress --bail",
     "copy-assets": "cp -r static build/static",
     "update-project": "echo YOU NEED TO DEFINE THIS IN YOUR PROJECT",
-    "build-static": "builder run update-project && builder run webpack-static && builder run copy-assets",
+    "build-static": "builder run clean-static && builder run update-project && builder run webpack-static && builder run copy-assets",
+    "clean-static": "rm -rf build",
     "open-static": "open http://localhost:8080",
     "server-static": "http-server build",
     "builder:check": "eslint config"


### PR DESCRIPTION
Seeing this error in the console: 

```
Clean webpack did not delete path: /Users/paula/work/formidable/code/victory-docs/build
```

Instead of using the `clean-webpack-plugin`, use a bash script to clean out the build. 

/cc @coopy @dvonlehman 
