### PR TITLE
Bug: Reference Error navigator is undefined

### DIFF
--- a/config/webpack/webpack.config.static.js
+++ b/config/webpack/webpack.config.static.js
@@ -51,11 +51,12 @@ module.exports = {
         // Needed for: `./~/bowser/src/bowser.js`
         userAgent: ""
       },
-      window: {},
-      document: {
+      window: {
         // Optional client-side render checks whether document is undefined
         // instead check whether it's being shimmed
-        shim: true,
+        __STATIC_GENERATOR: true
+      },
+      document: {
         // Needed for: `./~/formidable-landers/~/radium/lib/keyframes.js`
         createElement: function () {
           // Needs to return something for code like: `"draggable" in document.createElement("div")`

--- a/config/webpack/webpack.config.static.js
+++ b/config/webpack/webpack.config.static.js
@@ -45,6 +45,25 @@ module.exports = {
     new StatsWriterPlugin({
       filename: "stats.json"
     }),
-    new StaticSiteGeneratorPlugin("main", routes)
+    new StaticSiteGeneratorPlugin("main", routes, null, {
+      // Shim browser globals.
+      navigator: {
+        // Needed for: `./~/bowser/src/bowser.js`
+        userAgent: ""
+      },
+      window: {},
+      document: {
+        // Needed for: `./~/formidable-landers/~/radium/lib/keyframes.js`
+        createElement: function () {
+          // Needs to return something for code like: `"draggable" in document.createElement("div")`
+          return {
+            setAttribute: function () {}
+          };
+        },
+        head: {
+          appendChild: function () {}
+        }
+      }
+    })
   ]
 };

--- a/config/webpack/webpack.config.static.js
+++ b/config/webpack/webpack.config.static.js
@@ -31,8 +31,8 @@ module.exports = {
   plugins: [
     new webpack.DefinePlugin({
       "process.env": {
-        // Disable warnings for static build
-        NODE_ENV: JSON.stringify("production")
+        // On travis, production will disable warnings for static build
+        NODE_ENV: JSON.stringify(process.env.NODE_ENV || "staging")
       }
     }),
     new webpack.optimize.DedupePlugin(),
@@ -53,6 +53,9 @@ module.exports = {
       },
       window: {},
       document: {
+        // Optional client-side render checks whether document is undefined
+        // instead check whether it's being shimmed
+        shim: true,
         // Needed for: `./~/formidable-landers/~/radium/lib/keyframes.js`
         createElement: function () {
           // Needs to return something for code like: `"draggable" in document.createElement("div")`

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "handlebars-loader": "^1.1.4",
     "image-webpack-loader": "^1.6.3",
     "raw-loader": "0.5.1",
-    "static-site-generator-webpack-plugin": "2.0.1",
+    "static-site-generator-webpack-plugin": "2.1.0",
     "webpack": "1.12.9",
     "webpack-stats-plugin": "0.1.1"
   },


### PR DESCRIPTION
- Upgrade `static-site-generator-webpack-plugin`
- Shim browser globals using the above plugin’s [scope](https://github.com/markdalgleish/static-site-generator-webpack-plugin#scope)
- Default to staging environment
