### PR TITLE
Add Element global

### DIFF
--- a/config/webpack/webpack.config.static.js
+++ b/config/webpack/webpack.config.static.js
@@ -70,6 +70,7 @@ module.exports = {
           appendChild: function () {}
         }
       },
+      // Needed for ecology's clipboard.js dependency
       Element: function () {}
     }),
     // Webpack's `--bail` option seems to **still** not be terminating the build

--- a/config/webpack/webpack.config.static.js
+++ b/config/webpack/webpack.config.static.js
@@ -69,7 +69,8 @@ module.exports = {
         head: {
           appendChild: function () {}
         }
-      }
+      },
+      Element: function () {}
     }),
     // Webpack's `--bail` option seems to **still** not be terminating the build
     // with a non-zero exit code. This is the suggested interim hack.


### PR DESCRIPTION
This adds the Element global, which will fix the build for radium-docs.

This is related to https://github.com/FormidableLabs/builder-docs-archetype/pull/7

/cc @paulathevalley 
