### PR TITLE
Collapse static-entry.jsx and entry.jsx to just entry.js

### DIFF
--- a/config/webpack/webpack.config.dev.js
+++ b/config/webpack/webpack.config.dev.js
@@ -23,7 +23,7 @@ module.exports = {
   context: SRC,
   devtool: "source-map",
   entry: {
-    app: [path.join(SRC, "components", "entry.jsx")]
+    app: [path.join(SRC, "components", "entry.js")]
   },
   stats: {
     colors: true,

--- a/config/webpack/webpack.config.static.js
+++ b/config/webpack/webpack.config.static.js
@@ -19,7 +19,7 @@ var routes = require(path.join(ROOT, "static-routes"));
 
 module.exports = {
   entry: {
-    main: [path.join(SRC, "components", "static-entry.jsx")]
+    main: [path.join(SRC, "components", "entry.js")]
   },
   output: {
     path: path.join(ROOT, OUTPUT_DIR),


### PR DESCRIPTION
This resolves https://github.com/FormidableLabs/builder-docs-archetype/issues/14 and let's us soon resolve https://github.com/FormidableLabs/victory-docs/issues/26

This should coincide with a major version change to v2.0.0
