### PR TITLE
http-server -> ecstatic for customizable baseDir

### DIFF
--- a/dev/package.json
+++ b/dev/package.json
@@ -9,12 +9,12 @@
   "dependencies": {
     "babel-eslint": "^5.0.0",
     "chai": "^3.5.0",
+    "ecstatic": "^1.4.1",
     "eslint": "^1.10.3",
     "eslint-config-defaults": "^8.0.2",
     "eslint-plugin-filenames": "^0.2.0",
     "eslint-plugin-flow-vars": "^0.1.3",
     "eslint-plugin-react": "^3.16.1",
-    "http-server": "^0.8.5",
     "mocha": "^2.5.3",
     "phantomjs-prebuilt": "^2.1.7",
     "rowdy": "^0.5.0",

--- a/dev/spec-setup.js
+++ b/dev/spec-setup.js
@@ -47,28 +47,28 @@ var serveDev = function (cb) {
   wdsServer.listen(SERVER_PORT, SERVER_HOST, cb);
 };
 
+global.TEST_FUNC_BASE_DIR = process.env.TEST_FUNC_BASE_DIR || "/";
+global.TEST_FUNC_BASE_URL = process.env.TEST_FUNC_BASE_URL || "http://" + SERVER_HOST + ":" + SERVER_PORT + global.TEST_FUNC_BASE_DIR;
 
 /*
  * Serve static ./build dir
  */
 
 var serveStatic = function (cb) {
-  console.log("Starting static http-server...");
-  var httpServer = require("http-server");
-  var server = httpServer.createServer({
-    root: "./build"
-  });
-  server.listen(SERVER_PORT, SERVER_HOST, cb);
-};
+  console.log("Starting static server...");
+  var http = require("http");
+  var ecstatic = require("ecstatic");
 
+  http.createServer(
+    ecstatic({ root: "./build", baseDir: global.TEST_FUNC_BASE_DIR })
+  ).listen(SERVER_PORT, SERVER_HOST, cb);
+};
 
 /*
  * Before tests run, determine URL and server needs
  */
 
 before(function (done) {
-  global.TEST_FUNC_BASE_URL = process.env.TEST_FUNC_BASE_URL || "http://" + SERVER_HOST + ":" + SERVER_PORT + "/";
-
   switch (process.env.TEST_FUNC) {
   case "static": return serveStatic(done);
   case "dev": return serveDev(done);

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build-static": "builder run clean-static && builder run update-project && builder run webpack-static && builder run copy-assets",
     "clean-static": "rm -rf build",
     "open-static": "open http://localhost:8080",
-    "server-static": "ecstatic build",
+    "server-static": "ecstatic --port 8080 build",
     "builder:check": "eslint config",
     "test-func-remote": "TEST_FUNC=remote mocha --opts ./test/func/mocha.opts",
     "test-func-static": "TEST_FUNC=static mocha --opts ./test/func/mocha.opts",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build-static": "builder run clean-static && builder run update-project && builder run webpack-static && builder run copy-assets",
     "clean-static": "rm -rf build",
     "open-static": "open http://localhost:8080",
-    "server-static": "http-server build",
+    "server-static": "ecstatic build",
     "builder:check": "eslint config",
     "test-func-remote": "TEST_FUNC=remote mocha --opts ./test/func/mocha.opts",
     "test-func-static": "TEST_FUNC=static mocha --opts ./test/func/mocha.opts",


### PR DESCRIPTION
This PR changes from http-server for static serving to ecstatic. This allows us to customize the base path. E.g., `localhost:8080/open-source/project/*` instead of just `localhost:8080/*`. Now we can simulate the production environment better during tests. 

/cc @coopy @kylecesmat 
