### PR TITLE
Add baseUrl to webdriverio

### DIFF
--- a/dev/package.json
+++ b/dev/package.json
@@ -15,6 +15,7 @@
     "eslint-plugin-filenames": "^0.2.0",
     "eslint-plugin-flow-vars": "^0.1.3",
     "eslint-plugin-react": "^3.16.1",
+    "lodash.defaultsdeep": "^4.5.0",
     "mocha": "^2.5.3",
     "phantomjs-prebuilt": "^2.1.7",
     "rowdy": "^0.5.0",

--- a/dev/spec-setup.js
+++ b/dev/spec-setup.js
@@ -1,5 +1,6 @@
 /* eslint-disable global-require, no-console */
 var rowdy = require("rowdy");
+var defaults = require("lodash.defaultsdeep");
 var MochaAdapter = rowdy.adapters.mocha;
 
 var SERVER_HOST = "127.0.0.1";
@@ -7,9 +8,22 @@ var SERVER_PORT = "3000";
 global.TEST_FUNC_BASE_DIR = process.env.TEST_FUNC_BASE_DIR || "";
 global.TEST_FUNC_BASE_URL = process.env.TEST_FUNC_BASE_URL || "http://" + SERVER_HOST + ":" + SERVER_PORT + global.TEST_FUNC_BASE_DIR;
 
-var config = require("rowdy/config");
-config.options.driverLib = "webdriverio";
-config.settings.local.default.remote = { baseUrl: global.TEST_FUNC_BASE_URL };
+var base = require("rowdy/config");
+var config = defaults({
+  options: {
+    driverLib: "webdriverio"
+  },
+  settings: {
+    local: {
+      default: {
+        remote: {
+          // http://webdriver.io/guide/getstarted/configuration.html#baseUrl
+          baseUrl: global.TEST_FUNC_BASE_URL
+        }
+      }
+    }
+  }
+}, base);
 rowdy(config);
 
 var adapter = new MochaAdapter();

--- a/dev/spec-setup.js
+++ b/dev/spec-setup.js
@@ -5,7 +5,10 @@ var MochaAdapter = rowdy.adapters.mocha;
 
 var SERVER_HOST = "127.0.0.1";
 var SERVER_PORT = "3000";
+
+// Base directory for app on server, e.g., /open-source/victory
 global.TEST_FUNC_BASE_DIR = process.env.TEST_FUNC_BASE_DIR || "";
+// Full app server url, e.g., http://localhost:3000/open-source/victory
 global.TEST_FUNC_BASE_URL = process.env.TEST_FUNC_BASE_URL || "http://" + SERVER_HOST + ":" + SERVER_PORT + global.TEST_FUNC_BASE_DIR;
 
 var base = require("rowdy/config");

--- a/dev/spec-setup.js
+++ b/dev/spec-setup.js
@@ -1,10 +1,15 @@
 /* eslint-disable global-require, no-console */
-
 var rowdy = require("rowdy");
 var MochaAdapter = rowdy.adapters.mocha;
 
+var SERVER_HOST = "127.0.0.1";
+var SERVER_PORT = "3000";
+global.TEST_FUNC_BASE_DIR = process.env.TEST_FUNC_BASE_DIR || "";
+global.TEST_FUNC_BASE_URL = process.env.TEST_FUNC_BASE_URL || "http://" + SERVER_HOST + ":" + SERVER_PORT + global.TEST_FUNC_BASE_DIR;
+
 var config = require("rowdy/config");
 config.options.driverLib = "webdriverio";
+config.settings.local.default.remote = { baseUrl: global.TEST_FUNC_BASE_URL };
 rowdy(config);
 
 var adapter = new MochaAdapter();
@@ -21,10 +26,6 @@ beforeEach(function () {
 
 adapter.afterEach();
 adapter.after();
-
-var SERVER_HOST = "127.0.0.1";
-var SERVER_PORT = "3000";
-
 
 /*
  * Serve src with webpack-dev-server
@@ -46,9 +47,6 @@ var serveDev = function (cb) {
 
   wdsServer.listen(SERVER_PORT, SERVER_HOST, cb);
 };
-
-global.TEST_FUNC_BASE_DIR = process.env.TEST_FUNC_BASE_DIR || "";
-global.TEST_FUNC_BASE_URL = process.env.TEST_FUNC_BASE_URL || "http://" + SERVER_HOST + ":" + SERVER_PORT + global.TEST_FUNC_BASE_DIR;
 
 /*
  * Serve static ./build dir


### PR DESCRIPTION
This allows tests to route without worrying about the baseUrl (e.,g., `/open-source/victory` vs `/` depending on test environment).

```
return adapter.client
  .url("/docs")
  ...
```

instead of

```
return adapter.client
  .url(global.TEST_FUNC_BASE_URL + "/docs")
  ...
```
