### PR TITLE
Use file loader for image files

### DIFF
--- a/config/webpack/webpack.config.base.js
+++ b/config/webpack/webpack.config.base.js
@@ -33,9 +33,10 @@ module.exports = {
           require.resolve("image-webpack-loader")
         ]
       }, {
-        test: /.(png|jpg|gif)$/,
+        test: /\.(png|jpg|gif)$/,
         loaders: [
-          require.resolve("file-loader")
+          require.resolve("file-loader"),
+          require.resolve("image-webpack-loader")
         ]
       }, {
         test: /\.hbs$/,

--- a/config/webpack/webpack.config.base.js
+++ b/config/webpack/webpack.config.base.js
@@ -27,10 +27,15 @@ module.exports = {
           presets: ["es2015", "stage-1", "react"]
         }
       }, {
-        test: /.(png|jpg|svg)$/,
+        test: /\.svg$/,
         loaders: [
           require.resolve("raw-loader"),
           require.resolve("image-webpack-loader")
+        ]
+      }, {
+        test: /.(png|jpg|gif)$/,
+        loaders: [
+          require.resolve("file-loader")
         ]
       }, {
         test: /\.hbs$/,


### PR DESCRIPTION
The `raw-loader` did not work for the background image in the `<Header />` component of `formidable-landers`. The `file-loader` should resolve it correctly. 
