### PR TITLE
dont transpile victory deps

### DIFF
--- a/config/webpack/webpack.config.base.js
+++ b/config/webpack/webpack.config.base.js
@@ -17,11 +17,7 @@ module.exports = {
         // Make sure to formidable-landers is excluded for `npm link` purposes
         include: [
           path.resolve(SRC),
-          path.resolve(ROOT, "node_modules", "victory-docs"),
-          path.resolve(ROOT, "node_modules", "victory-chart"),
-          path.resolve(ROOT, "node_modules", "victory-core"),
-          path.resolve(ROOT, "node_modules", "victory-examples"),
-          path.resolve(ROOT, "node_modules", "victory-pie")
+          path.resolve(ROOT, "node_modules", "victory-docs")
         ],
         loader: require.resolve("babel-loader"),
         query: {


### PR DESCRIPTION
cc/ @paulathevalley @ryan-roemer 

Since we aren't pulling ecology docs out of npm packages any more, we don't need to transpile these packages. I'm not sure whether `node_modules/victory-docs` should also be removed here, as I'm not exactly sure why it is being included.

related to https://github.com/FormidableLabs/victory-docs/pull/175
