### PR TITLE
Add production flag to preversion

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint-config": "eslint ./*.js",
     "lint-react": "eslint --ext .js,.jsx src",
     "lint-test": "eslint --ext .js,.jsx test",
-    "npm:preversion": "builder run lint && --env='{"NODE_ENV":"production"}' builder run build-static",
+    "npm:preversion": "builder run lint && builder --env='{\"NODE_ENV\":\"production\"}' run build-static",
     "open-static": "open http://localhost:8080",
     "server-static": "ecstatic --port 8080 build",
     "test-func-dev": "TEST_FUNC=dev mocha --opts ./test/func/mocha.opts",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint-config": "eslint ./*.js",
     "lint-react": "eslint --ext .js,.jsx src",
     "lint-test": "eslint --ext .js,.jsx test",
-    "npm:preversion": "builder run lint && builder run build-static",
+    "npm:preversion": "builder run lint && NODE_ENV=production builder run build-static",
     "open-static": "open http://localhost:8080",
     "server-static": "ecstatic --port 8080 build",
     "test-func-dev": "TEST_FUNC=dev mocha --opts ./test/func/mocha.opts",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint-config": "eslint ./*.js",
     "lint-react": "eslint --ext .js,.jsx src",
     "lint-test": "eslint --ext .js,.jsx test",
-    "npm:preversion": "builder run lint && NODE_ENV=production builder run build-static",
+    "npm:preversion": "builder run lint && --env='{"NODE_ENV":"production"}' builder run build-static",
     "open-static": "open http://localhost:8080",
     "server-static": "ecstatic --port 8080 build",
     "test-func-dev": "TEST_FUNC=dev mocha --opts ./test/func/mocha.opts",


### PR DESCRIPTION
This PR adds the production flag to the `npm:preversion` task. This will use the correct template, fix the `<base href="">`, and use the proper `<title>` tags per page. 

/cc @ryan-roemer 