### PR TITLE
replace deprecated method

### DIFF
--- a/dev/spec-setup.js
+++ b/dev/spec-setup.js
@@ -38,7 +38,7 @@ adapter.beforeEach();
 
 beforeEach(function () {
   return adapter.client
-    .timeoutsImplicitWait(ELEM_WAIT); // Set timeout for waiting on elements.
+    .timeouts("implicit", ELEM_WAIT); // Set timeout for waiting on elements.
 });
 
 adapter.afterEach();


### PR DESCRIPTION
We were seeing a spurious CI failure in `victory-docs` https://github.com/FormidableLabs/victory-docs/issues/292

I believe it was caused by [this update](https://github.com/webdriverio/webdriverio/blob/master/CHANGELOG.md#v480-2017-04-30) to `webdriverio`